### PR TITLE
Fix missing RSS scraper backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ To run this project locally, follow these steps:
 
 1. Clone the repository: `git clone https://github.com/yourusername/rss_scraper.git`
 2. Navigate into the project directory: `cd rss_scraper`
-3. Open `index.html` in your browser.
+3. Install the dependencies: `pip install -r requirements.txt`
+4. Start the backend server: `python app.py`
+5. Open `index.html` in your browser.
 
 ## Features
 

--- a/app.py
+++ b/app.py
@@ -1,0 +1,42 @@
+from flask import Flask, request, jsonify
+import requests
+from bs4 import BeautifulSoup
+from urllib.parse import urljoin
+
+app = Flask(__name__)
+
+@app.route('/scrape_rss')
+def scrape_rss():
+    """Fetch RSS/Atom links from a given URL."""
+    url = request.args.get('url')
+    if not url:
+        return jsonify({'error': 'Missing url parameter'}), 400
+
+    headers = {
+        'User-Agent': (
+            'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) '
+            'AppleWebKit/537.36 (KHTML, like Gecko) '
+            'Chrome/114.0 Safari/537.36'
+        )
+    }
+
+    try:
+        resp = requests.get(url, headers=headers, timeout=15)
+        resp.raise_for_status()
+    except requests.RequestException as exc:
+        return jsonify({'error': str(exc)}), 500
+
+    soup = BeautifulSoup(resp.text, 'html.parser')
+    rss_links = []
+    for tag in soup.find_all('link', type=['application/rss+xml', 'application/atom+xml']):
+        href = tag.get('href')
+        if href:
+            rss_links.append({
+                'title': tag.get('title', ''),
+                'link': urljoin(resp.url, href)
+            })
+
+    return jsonify({'rss_links': rss_links})
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+flask
+requests
+beautifulsoup4


### PR DESCRIPTION
## Summary
- add Flask backend to scrape RSS feeds
- document setup steps in README
- list Python dependencies in requirements.txt

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_687f86226a988328b534685fcebb1a53