### PR TITLE
Add PORT env option

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ To run this project locally, follow these steps:
 2. Navigate into the project directory: `cd rss_scraper`
 3. Install the dependencies: `pip install -r requirements.txt`
 4. Start the backend server: `python app.py`
+   - Optionally set the `PORT` environment variable to change the port (defaults to `5000`), e.g. `PORT=8000 python app.py`.
 5. Open `index.html` in your browser.
 
 ## Features

--- a/app.py
+++ b/app.py
@@ -1,4 +1,5 @@
 from flask import Flask, request, jsonify
+import os
 
 from bs4 import BeautifulSoup
 import requests
@@ -36,4 +37,5 @@ def scrape_rss():
 
 
 if __name__ == '__main__':
-    app.run(debug=True)
+    port = int(os.getenv('PORT', 5000))
+    app.run(debug=True, port=port)


### PR DESCRIPTION
## Summary
- allow port override via PORT environment variable
- document PORT usage in README

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_687fa2818eb08328a177b25a4049160f